### PR TITLE
fix: Day02 dungeon parseRanges to handle comma-separated input

### DIFF
--- a/src/main/kotlin/aoc/adventure/dungeons/Day02DungeonPuzzle.kt
+++ b/src/main/kotlin/aoc/adventure/dungeons/Day02DungeonPuzzle.kt
@@ -91,10 +91,14 @@ class Day02DungeonPuzzle : DungeonPuzzle {
     }
 
     private fun parseRanges(input: List<String>): List<Pair<Long, Long>> {
-        return input.filter { it.isNotBlank() }.map { line ->
-            val parts = line.split("-")
-            parts[0].toLong() to parts[1].toLong()
-        }
+        // Input format: comma-separated ranges on a single line (e.g., "12077-25471,4343258-4520548,...")
+        return input.filter { it.isNotBlank() }
+            .flatMap { line -> line.split(",") }
+            .filter { it.isNotBlank() }
+            .map { range ->
+                val (start, end) = range.trim().split("-").map { it.toLong() }
+                start to end
+            }
     }
 
     private fun countDoubledInRange(start: Long, end: Long): Long {


### PR DESCRIPTION
## Summary
Fix NumberFormatException in Day02 dungeon puzzle when parsing input ranges.

## Problem
The input file has comma-separated ranges on a single line:
```
12077-25471,4343258-4520548,53-81,...
```

But `parseRanges()` was treating each line as a single hyphen-separated range, causing it to try parsing `25471,4343258` as a Long.

## Solution
Updated `parseRanges()` to split by comma first, then by hyphen, matching the format used in `Day02.kt`.

## Test plan
- [x] Code compiles successfully
- [x] Run `./gradlew adventure` and complete Day 02 dungeon

Fixes #8